### PR TITLE
fix(common): appex-268 update jschannel package

### DIFF
--- a/.github/workflows/validate-workflow.yaml
+++ b/.github/workflows/validate-workflow.yaml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [main]
+    branches: [ $default-branch ]
   pull_request:
-    branches: [main]
+    branches: [ $default-branch ]
 
 jobs:
   build:
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 17.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - name: Checkout code
@@ -23,6 +24,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
 
     - name: Install Dependencies
       run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.5.1",
-        "jschannel": "git+ssh://git@github.com/meenie/jschannel.git#0.0.5",
+        "jschannel": "git+https://github.com/meenie/jschannel.git",
         "lint-staged": "^12.3.5",
         "lodash-webpack-plugin": "^0.11.6",
         "prettier": "^2.5.1",
@@ -7611,8 +7611,7 @@
     },
     "node_modules/jschannel": {
       "version": "0.0.5",
-      "resolved": "git+ssh://git@github.com/meenie/jschannel.git#ab94457df25291600314d7449e8cdfa8c790dc0b",
-      "integrity": "sha512-2w348gKhGseOjlrBG7bZ4UceHD74tLB/ki1YbLgY5bd8bjrAdAKSyndtDUrBOLsEF2UB1c6RmdccHdjXs+AVqQ==",
+      "resolved": "git+https://git@github.com/meenie/jschannel.git#ab94457df25291600314d7449e8cdfa8c790dc0b",
       "dev": true,
       "license": "MPL 1.1/GPL 2.0/LGPL 2.1"
     },
@@ -15813,10 +15812,9 @@
       }
     },
     "jschannel": {
-      "version": "git+ssh://git@github.com/meenie/jschannel.git#ab94457df25291600314d7449e8cdfa8c790dc0b",
-      "integrity": "sha512-2w348gKhGseOjlrBG7bZ4UceHD74tLB/ki1YbLgY5bd8bjrAdAKSyndtDUrBOLsEF2UB1c6RmdccHdjXs+AVqQ==",
+      "version": "git+https://git@github.com/meenie/jschannel.git#ab94457df25291600314d7449e8cdfa8c790dc0b",
       "dev": true,
-      "from": "jschannel@https://github.com/meenie/jschannel.git#ab94457df25291600314d7449e8cdfa8c790dc0b"
+      "from": "jschannel@git+https://github.com/meenie/jschannel.git"
     },
     "jsdom": {
       "version": "16.7.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.5.1",
-    "jschannel": "git+ssh://git@github.com/meenie/jschannel.git#0.0.5",
+    "jschannel": "git+https://github.com/meenie/jschannel.git",
     "lint-staged": "^12.3.5",
     "lodash-webpack-plugin": "^0.11.6",
     "prettier": "^2.5.1",


### PR DESCRIPTION
## What?
Updates the jschannel package from using `ssh` to `https` - hopefully, this will resolve the issue w/ GH Actions not being able to pull the package and then failing.

## Why?
[APPEX-268](https://jira.bigcommerce.com/browse/APPEX-268)

## Testing / Proof
pushed changes to GH to resolve the Actions bug.

@bigcommerce/gta-dt
